### PR TITLE
Drop the staging index

### DIFF
--- a/migrations/20170906145247_fix_indexes.js
+++ b/migrations/20170906145247_fix_indexes.js
@@ -1,0 +1,10 @@
+
+exports.up = (knex) => knex.schema
+  .table('staging', (table) => {
+    table.dropIndex('uploaded');
+  });
+
+exports.down = (knex) => knex.schema
+  .table('staging', (table) => {
+    table.index('uploaded');
+  });


### PR DESCRIPTION
Glen,
We were thinking about dropping this index on the staging table to see what impact this has on the database size. As it turns out, the knex down() was wrong also, and I think this would break any genuine rollbacks beyond this point.